### PR TITLE
Fix pluginURL

### DIFF
--- a/ssh.plg
+++ b/ssh.plg
@@ -5,7 +5,7 @@
 <!ENTITY author     "docgyver">
 <!ENTITY version    "2021.12.01">
 <!ENTITY category   "Network Services">
-<!ENTITY pluginURL  "https://raw.github.com/docgyver/unraid-v6-plugins/master/&name;.plg">
+<!ENTITY pluginURL  "https://raw.githubusercontent.com/docgyver/unraid-v6-plugins/master/&name;.plg">
 <!ENTITY packageURL "https://github.com/docgyver/unraid-v6-plugins/releases/download/&name;">
 <!ENTITY devplugin  "false">
 ]>


### PR DESCRIPTION
raw.github.com produces a 404 not found which lets the plugin install fail, need to use raw.githubusercontent.com