### PR TITLE
Ciphers option for CVE-2023-48795 workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ When you enter the SSH plug-in, all users are listed and you are able to choose 
 
   If this option is set to "no" but the user you wish to login with has a blank password, then SSH login will not be possible.  The exception to this is rule is when a user has been configured with a public / private key pair.
 
+* `Ciphers`
+
+  This option allows you to select the encryption ciphers that are allowed for SSH connections.  The default setting is for this plugin is *blank*. This means that the default ciphers for your system will be used. This option was added to allow workarounds for [CVE-2023-48795](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48795) while UNRAID is still using an unpatched version of OpenSSH.
+  My recommendation is to set this to `aes128-gcm@openssh.com,aes256-gcm@openssh.com` to be certain that you are not using any of the ciphers that are vulnerable to this exploit.
+  However, if you know what you are doing you can just use `-chacha20-poly1305@openssh.com` (Be sure to include the '-' at the beginning of the string). You will need to make sure you are also not explicitly enabling any `aes(128|192|256)-cbc` ciphers while using the default MACs. See [this link](https://jfrog.com/blog/ssh-protocol-flaw-terrapin-attack-cve-2023-48795-all-you-need-to-know/) for more details.
+
 >**Scenario 1:** you require SSH access for *root*.  *root* already has a password...
 >- Enable option `PermitRootUser`
 >- Enable option `Password Authentication`
@@ -94,7 +100,7 @@ The plug-in has been designed to check for the existance of a public key for eac
 
 ***
 ## Support
-Please provide feedback to any problems encountered or to request enhancements or missing features that you would like to see added.  
+Please provide feedback to any problems encountered or to request enhancements or missing features that you would like to see added.
 
 Support requests should be made in the UnRAID forum. Please use the following thread for all support queries;
 (http://lime-technology.com/forum/index.php?topic=47289.0)<br>

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ When you enter the SSH plug-in, all users are listed and you are able to choose 
 
 * `Ciphers`
 
-  This option allows you to select the encryption ciphers that are allowed for SSH connections.  The default setting is for this plugin is *blank*. This means that the default ciphers for your system will be used. This option was added to allow workarounds for [CVE-2023-48795](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48795) while UNRAID is still using an unpatched version of OpenSSH.
+  This option allows you to select the encryption ciphers that are allowed for SSH connections. The default setting is for this plugin is *blank*. This means that the default ciphers for the system will be used. This option was added to allow workarounds for [CVE-2023-48795](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48795) while UNRAID is still using an unpatched version of OpenSSH.
+  This is entirely optional, and whether or not you want to change this setting depends on your threat model.
   My recommendation is to set this to `aes128-gcm@openssh.com,aes256-gcm@openssh.com` to be certain that you are not using any of the ciphers that are vulnerable to this exploit.
-  However, if you know what you are doing you can just use `-chacha20-poly1305@openssh.com` (Be sure to include the '-' at the beginning of the string). You will need to make sure you are also not explicitly enabling any `aes(128|192|256)-cbc` ciphers while using the default MACs. See [this link](https://jfrog.com/blog/ssh-protocol-flaw-terrapin-attack-cve-2023-48795-all-you-need-to-know/) for more details.
+  However, you could also just set it to `-chacha20-poly1305@openssh.com` (be certain to include the '-' at the beginning of the string). You will need to make sure you are also not enabling any `aes(128|192|256)-cbc` ciphers while using the default MACs. See [this link](https://jfrog.com/blog/ssh-protocol-flaw-terrapin-attack-cve-2023-48795-all-you-need-to-know/) for more details.
 
 >**Scenario 1:** you require SSH access for *root*.  *root* already has a password...
 >- Enable option `PermitRootUser`

--- a/ssh.plg
+++ b/ssh.plg
@@ -3,7 +3,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name       "ssh">
 <!ENTITY author     "docgyver">
-<!ENTITY version    "2023.07.27.1">
+<!ENTITY version    "2024.01.03.1">
 <!ENTITY category   "Network Services">
 <!ENTITY launch     "Settings/&name;">
 <!ENTITY pluginURL  "https://raw.githubusercontent.com/docgyver/unraid-v6-plugins/master/&name;.plg">
@@ -19,6 +19,9 @@
          pluginURL="&pluginURL;">
 
 <CHANGES>
+###2024.01.03###
+- Added option to manually set Ciphers to workaround CVE-2023-48795
+  - Reccommendation is to use: aes128-gcm@openssh.com,aes256-gcm@openssh.com
 ###2023.07.27###
 - Added prohibit-password option to PermitRootLogin
 - BugFix: Fixed Display of Online Version in the UI
@@ -352,6 +355,12 @@ $sshversion = shell_exec("/usr/bin/ssh -V 2>&1");
       </td>
       </tr>
       <tr>
+        <td>Ciphers:</td>
+        <td>
+          <input type="text" name="arg9" id="arg9" maxlength="999" value="<?= $ssh_cfg['CIPHERS']; ?>">
+        </td>
+      </tr>
+      <tr>
     </table>
 
     <div align="center">
@@ -389,6 +398,7 @@ function validateForm() {
   document.getElementById('arg6').disabled = false;
   document.getElementById('arg7').disabled = false;
   document.getElementById('arg8').disabled = false;
+  document.getElementById('arg9').disabled = false;
   return(true);
 }
 
@@ -404,6 +414,7 @@ function checkRUNNING(form) {
     form.arg6.disabled = true;
     form.arg7.disabled = true;
     form.arg8.disabled = true;
+    form.arg9.disabled = true;
   }
 }
 
@@ -503,6 +514,8 @@ ssh_buttonstart()
   read fill PASSWORDAUTHENTICATION < <(egrep "#?PasswordAuthentication " /etc/ssh/sshd_config)
   read fill PERMITEMPTYPASSWORDS < <(egrep "#?PermitEmptyPasswords " /etc/ssh/sshd_config)
   read fill GATEWAYPORTS < <(egrep "#?GatewayPorts " /etc/ssh/sshd_config)
+  # only read Ciphers if it is active in the sshd_config file
+  read fill CIPHERS < <(egrep "^Ciphers " /etc/ssh/sshd_config)
 
   write_config
   ssh_start
@@ -523,6 +536,7 @@ write_config()
   echo "PASSWORDAUTHENTICATION=\"$PASSWORDAUTHENTICATION\"" >> /boot/config/plugins/ssh/ssh.cfg
   echo "PERMITEMPTYPASSWORDS=\"$PERMITEMPTYPASSWORDS\"" >> /boot/config/plugins/ssh/ssh.cfg
   echo "GATEWAYPORTS=\"$GATEWAYPORTS\"" >> /boot/config/plugins/ssh/ssh.cfg
+  echo "CIPHERS=\"$CIPHERS\"">> /boot/config/plugins/ssh/ssh.cfg
   sed -i 's/^#\?AllowUsers .*/AllowUsers root/' /etc/ssh/sshd_config
 
   # only loop thru userlist if some/one were selected in webgui.  no users selected = -1
@@ -574,7 +588,7 @@ write_config()
     if [[ $PERMITROOTLOGIN != "no" ]]; then
       [ ! -d /root/.ssh ] && mkdir /root/.ssh
       if [ -f /boot/config/plugins/ssh/root/.ssh/authorized_keys ]; then
-  	    cp --preserve=timestamps -p /boot/config/plugins/ssh/root/.ssh/authorized_keys /root/.ssh/authorized_keys
+        cp --preserve=timestamps -p /boot/config/plugins/ssh/root/.ssh/authorized_keys /root/.ssh/authorized_keys
         chmod 700 /root/.ssh
         chmod 600 /root/.ssh/authorized_keys
         chown root:root /root/.ssh/authorized_keys
@@ -585,12 +599,27 @@ write_config()
 
   # update sshd_config file with values set in webgui
   # only update when the Keyword is find at the beginning of the line (^#\?)
+  # EXECPTION: Ciphers will append to the end of the file if it doesn't exist yet
   sed -i 's/^#\?Port .*/Port '$PORT'/' /etc/ssh/sshd_config
   sed -i 's/^#\?PermitRootLogin .*/PermitRootLogin '$PERMITROOTLOGIN'/' /etc/ssh/sshd_config
   sed -i 's/^#\?MaxAuthTries .*/MaxAuthTries '$MAXAUTHTRIES'/' /etc/ssh/sshd_config
   sed -i 's/^#\?PasswordAuthentication .*/PasswordAuthentication '$PASSWORDAUTHENTICATION'/' /etc/ssh/sshd_config
   sed -i 's/^#\?PermitEmptyPasswords .*/PermitEmptyPasswords '$PERMITEMPTYPASSWORDS'/' /etc/ssh/sshd_config
   sed -i 's/^#\?GatewayPorts .*/GatewayPorts '$GATEWAYPORTS'/' /etc/ssh/sshd_config
+  # Check if the $CIPHERS variable is not empty
+  if [ -n "$CIPHERS" ]; then
+    # Check if an active Ciphers line exists in the sshd_config file
+    if ! grep -q "^Ciphers " /etc/ssh/sshd_config; then
+      # If no active Ciphers line, add it to the end of the file
+      echo "Ciphers $CIPHERS" >> /etc/ssh/sshd_config
+    else
+      # If an active Ciphers line exists, replace it
+      sed -i 's/^Ciphers .*/Ciphers '$CIPHERS'/' /etc/ssh/sshd_config
+    fi
+  else
+    # If $CIPHERS is empty, remove any uncommented Ciphers line
+    sed -i '/^Ciphers /d' /etc/ssh/sshd_config
+  fi
 
   # preserve live /etc/sshd_config file on flash. When unRAID reboots, the standard ssh startup baked into unRAID v6 will
   # copy all files from /boot/config/ssh to /etc/ssh. This ensures the correct config is maintained after a reboot. Failure
@@ -615,6 +644,7 @@ ssh_enable()
   PASSWORDAUTHENTICATION="$6"
   PERMITEMPTYPASSWORDS="$7"
   GATEWAYPORTS="$8"
+  CIPHERS="$9"
 
   write_config
   ssh_start
@@ -636,6 +666,7 @@ ssh_disable()
   PASSWORDAUTHENTICATION="$6"
   PERMITEMPTYPASSWORDS="$7"
   GATEWAYPORTS="$8"
+  CIPHERS="$9"
 
   write_config
   ssh_stop
@@ -655,10 +686,10 @@ case "$1" in
     ssh_restart
   ;;
   'enable')
-    ssh_enable $1 $2 $3 $4 $5 $6 $7 $8
+    ssh_enable $1 $2 $3 $4 $5 $6 $7 $8 $9
   ;;
   'disable')
-    ssh_disable $1 $2 $3 $4 $5 $6 $7 $8
+    ssh_disable $1 $2 $3 $4 $5 $6 $7 $8 $9
   ;;
   'buttonstart')
     ssh_buttonstart


### PR DESCRIPTION
Setting Ciphers is entirely optional, but can be used to workaround CVE-2023-48795 until Unraid incorporates a patched version of OpenSSH.

Unraid version: 9.3p2
Patched version: 9.6+